### PR TITLE
compatible with api v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   }], 
   "require": {
     "php": ">=5.5.0",
-    "guzzlehttp/guzzle": "5.1.0",
+    "guzzlehttp/guzzle": "^6.0",
     "cakephp/utility": "3.0.0-beta3"
   },
   "require-dev": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -32,7 +32,7 @@ final class Client implements ClientInterface
      * @var array
      */
     private $httpOptions = [
-        'base_url' => ['https://api.chatwork.com/{version}/', ['version' => 'v1']],
+        'base_url' => ['https://api.chatwork.com/{version}/', ['version' => 'v2']],
         'defaults' => [
             'timeout' => 60,
             'debug' => false,

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -15,7 +15,7 @@ class File implements EntityInterface
     public $account;
 
     /**
-     * @var int
+     * @var string
      */
     public $messageId;
 

--- a/src/Entity/Message.php
+++ b/src/Entity/Message.php
@@ -4,7 +4,7 @@ namespace Polidog\Chatwork\Entity;
 class Message implements EntityInterface 
 {
     /**
-     * @var int
+     * @var string
      */
     public $messageId;
 

--- a/src/Entity/Task.php
+++ b/src/Entity/Task.php
@@ -27,7 +27,7 @@ class Task implements EntityInterface
     public $assignedByAccount;
 
     /**
-     * @var int
+     * @var string
      */
     public $messageId;
 

--- a/tests/Api/Rooms/MessagesTest.php
+++ b/tests/Api/Rooms/MessagesTest.php
@@ -104,7 +104,7 @@ class MessagesTest extends \PHPUnit_Framework_TestCase
         Phake::when($response)
             ->json()
             ->thenReturn([
-                'message_id' => 123456
+                'message_id' => "123456"
             ]);
         
         $messages = new Messages(1, $httpClient);
@@ -123,7 +123,6 @@ class MessagesTest extends \PHPUnit_Framework_TestCase
         Phake::verify($response,Phake::times(1))
             ->json();
 
-        $this->assertEquals(123456, $message->messageId);        
-        
+        $this->assertEquals("123456", $message->messageId);
     }
-}    
+}

--- a/tests/Entity/Factory/FileFactoryTest.php
+++ b/tests/Entity/Factory/FileFactoryTest.php
@@ -19,7 +19,7 @@ class FileFactoryTest extends \PHPUnit_Framework_TestCase
                 "name":"Bob",
                 "avatar_image_url": "https://example.com/ico_avatar.png"
             },
-            "message_id": 22,
+            "message_id": "22",
             "filename": "README.md",
             "filesize": 2232,
             "upload_time": 1384414750
@@ -28,7 +28,7 @@ class FileFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(File::class, $entity);
         $this->assertInstanceOf(User::class, $entity->account);
         $this->assertEquals(3, $entity->fileId);
-        $this->assertEquals(22, $entity->messageId);
+        $this->assertEquals("22", $entity->messageId);
         $this->assertEquals(2232, $entity->filesize);
         $this->assertEquals(1384414750, $entity->uploadTime);
         

--- a/tests/Entity/Factory/MessageFactoryTest.php
+++ b/tests/Entity/Factory/MessageFactoryTest.php
@@ -14,7 +14,7 @@ class MessageFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $factory = new MessageFactory();
         $entity = $factory->entity(json_decode('{
-            "message_id": 5,
+            "message_id": "5",
             "account": {
               "account_id": 123,
               "name": "Bob",
@@ -28,7 +28,7 @@ class MessageFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Message::class, $entity);
         $this->assertInstanceOf(User::class, $entity->account);
         
-        $this->assertEquals(5, $entity->messageId);
+        $this->assertEquals("5", $entity->messageId);
         $this->assertEquals("Hello Chatwork!", $entity->body);
         $this->assertEquals(1384242850, $entity->sendTime);
         $this->assertEquals(0, $entity->updateTime);

--- a/tests/Entity/Factory/TaskFactoryTest.php
+++ b/tests/Entity/Factory/TaskFactoryTest.php
@@ -31,7 +31,7 @@ class TaskFactoryTest extends \PHPUnit_Framework_TestCase
               "name": "Anna",
               "avatar_image_url": "https://example.com/def.png"
             },
-            "message_id": 13,
+            "message_id": "13",
             "body": "buy milk",
             "limit_time": 1384354799,
             "status": "open"
@@ -43,7 +43,7 @@ class TaskFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(User::class, $entity->assignedByAccount);
         
         $this->assertEquals(3, $entity->taskId);
-        $this->assertEquals(13, $entity->messageId);
+        $this->assertEquals("13", $entity->messageId);
         $this->assertEquals('buy milk', $entity->body);
         $this->assertEquals(1384354799, $entity->limitTime);
         $this->assertEquals('open', $entity->status);


### PR DESCRIPTION
Chatwork API v2に対応しました。ご確認お願い致します。
refs: https://help.chatwork.com/hc/ja/articles/115000019401-2017-01-26-%E3%83%81%E3%83%A3%E3%83%83%E3%83%88%E3%83%AF%E3%83%BC%E3%82%AFAPI%E3%83%90%E3%83%BC%E3%82%B8%E3%83%A7%E3%83%B3%E3%82%A2%E3%83%83%E3%83%97%E3%81%AE%E3%81%8A%E7%9F%A5%E3%82%89%E3%81%9B

※尚、エンドポイントURI及びメッセージID形式のみ対応しており、新規追加されたコンタクト承認依頼APIには追随しておりません。